### PR TITLE
Adding docker-compose and Redux DevTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,99 @@
 # Welcome
+I have been exploring Docker - using `docker-compose` to spin up development environments for several projects. I wanted to find a simple project that would allow me to spin up a server-side rendered (SSR) app based on [create-react-app](https://github.com/facebook/create-react-app).
+
 This project was inspired by the excellent work of [Vladimir Feskov](https://github.com/vfeskov) and his [series of posts](https://vfeskov.com/tags/CRA-with-SSR-series/) covering server-side rendering with [create-react-app](https://github.com/facebook/create-react-app).
 
-The [original repo](https://github.com/vfeskov/cra-ssr) this project was forked from is available at [https://github.com/vfeskov/cra-ssr](https://github.com/vfeskov/cra-ssr)
+The [original repo](https://github.com/vfeskov/cra-ssr) this project was forked from is available at [https://github.com/vfeskov/cra-ssr](https://github.com/vfeskov/cra-ssr).
+
+# Docker
+If this is your first time getting Docker setup, please see "Initial setup and configuration" (below)
+
+If you already have Docker images/containers built that you wish to reuse:
+
+`$ docker-compose up -d && docker-compose logs -f`
+
+When you're ready to shut down your Docker containers:
+
+`$ docker-compose down`
+
+## Initial setup and configuration
+### Install Docker Community Edition
+If you do not have Docker installed on your machine, please download and install [Docker Community Edition](https://www.docker.com/community-edition) for your development machine.
+
+### Build and run Docker
+If you have [Docker](https://www.docker.com) installed and configured on your development machine, you can spin up the project by running:
+
+`$ docker-compose up -d && docker-compose logs -f`
+
+### Shut down Docker
+Once you have finished with your work - or if you would like to stop the project from running:
+
+`$ docker-compose down`
+
+#### BONUS: Docker cheatsheet
+I've created several helper scripts in my projects that invoke several Docker commands.
+
+If these scripts are defined within your `package.json` file, you can run them with:
+
+    $ npm run <script>
+
+If these scripts are not defined in your `package.json` file, no problem. I've included the appropriate Docker commands here for reference.
+
++ docker:containers:list
+    - List all Docker containers in your development environment
+
+      `$ docker ps -a`
+
++ docker:containers:stop
+    - Stop all Docker containers in your development environment.
+
+      `$ docker stop $(docker ps -aq)`
+
++ docker:down
+    - This shuts down - but does not delete - Docker containers in your development environment using your latest build.
+
+      `$ docker-compose down`
+
++ docker:images:list
+    - List all Docker images in your development environment.
+
+      `$ docker images`
+
++ docker:nuke:containers
+    - Destroys all containers in your development environment.
+
+      `$ docker rm $(docker ps -aq)`
+
++ docker:nuke:images
+    - Destroy all Docker images in your development environment.
+
+      `$ docker rmi -f $(docker images -q)`
+
++ docker:nuke
+    - This will wipe the slate clean and destroy all Docker containers and images in your development environment.
+
+      ```
+      // Stop all running containers
+      $ docker stop $(docker ps -aq)
+
+      // Remove all containers 
+      $ docker rm $(docker ps -aq)
+
+      // Remove all images 
+      $ docker rmi -f $(docker images -q)
+      ```
+
++ docker:up
+    - This spins up Docker containers in your development environment using your latest build. Initial terminal output will be a live tail of all Docker logs until you press CTRL+C to exit. Exiting will not shut down your Docker containers; it will only cancel the log output command.
+
+      `$ docker-compose up -d && docker-compose logs -f`
+
++ docker:up:build
+    - This is useful for building your Docker environment for the first time **OR** to rebuild containers and images from scratch. Initial terminal output will be a live tail of all Docker logs until you press CTRL+C to exit. Exiting will not shut down your Docker containers; it will only cancel the log output command.
+
+      `$ docker-compose up --build -d && docker-compose logs -f`
+
++ docker:up:timestamp
+    - If you want to see the timestamp in your logs, this is the command for you. Initial terminal output will be a live tail of all Docker logs until you press CTRL+C to exit. Exiting will not shut down your Docker containers; it will only cancel the log output command.
+
+      `$ docker-compose up -d && docker-compose logs -f -t`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-## Source code for CRA SSR posts on https://vfeskov.com
+# Welcome
+This project was inspired by the excellent work of [Vladimir Feskov](https://github.com/vfeskov) and his [series of posts](https://vfeskov.com/tags/CRA-with-SSR-series/) covering server-side rendering with [create-react-app](https://github.com/facebook/create-react-app).
 
-- [Part 1](https://github.com/vfeskov/cra-ssr/tree/part-1-setup)
-- [Part 2](https://github.com/vfeskov/cra-ssr/tree/part-2-enabling-ssr)
-- [Part 3](https://github.com/vfeskov/cra-ssr/tree/part-3-service-worker)
+The [original repo](https://github.com/vfeskov/cra-ssr) this project was forked from is available at [https://github.com/vfeskov/cra-ssr](https://github.com/vfeskov/cra-ssr)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ When you're ready to shut down your Docker containers:
 
 `$ docker-compose down`
 
+## Docker-compose? Why?
+Why would we want to use [docker-compose](https://docs.docker.com/compose/overview/)? Imagine the case we want to experiment with incorporating other services (containers) into our app - such as MongoDB, MySQL, Redis...[docker-compose](https://docs.docker.com/compose/overview/) allows us to spin up and spin down these containers as a group.
+
 ## Initial setup and configuration
 ### Install Docker Community Edition
 If you do not have Docker installed on your machine, please download and install [Docker Community Edition](https://www.docker.com/community-edition) for your development machine.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8289,6 +8289,11 @@
         "symbol-observable": "1.1.0"
       }
     },
+    "redux-devtools-extension": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz",
+      "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0="
+    },
     "redux-thunk": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.17",
     "redux": "^3.7.2",
+    "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
     "workbox-cli": "^2.1.2",
     "workbox-sw": "^2.1.2"

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -8,10 +8,11 @@ import thunkMiddleware from 'redux-thunk'
 import { Provider } from 'react-redux'
 import { createStore, applyMiddleware } from 'redux'
 import { root } from './reducers'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 const initState = window.__INIT_STATE__ && JSON.parse(window.__INIT_STATE__)
 
-const store = createStore(root, initState, applyMiddleware(thunkMiddleware))
+const store = createStore(root, initState, composeWithDevTools(applyMiddleware(thunkMiddleware)))
 
 ReactDOM.render(
   <Provider store={store}>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
 
   # rabbitmq:
   #   image: rabbitmq
+  #   container_name: "crassr-rabbitmq"
   #   ports:
   #     - "5672:5672"
   #   expose:
   #     - "5672"
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: ./Dockerfile
+    container_name: 'crassr-web'
+    restart: 'always'
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+
+  # mongodb:
+  #   image: mongo:latest
+  #   container_name: "crassr-mongodb"
+  #   environment:
+  #     - MONGO_DATA_DIR=/data/db
+  #     - MONGO_LOG_DIR=/dev/null
+  #   volumes:
+  #     - ./path/in/project/to/persist/mongodb/data/db:/data/db
+  #   ports:
+  #     - "27017:27017"
+  #   command: mongod --smallfiles --logpath=/dev/null # --quiet
+
+  # rabbitmq:
+  #   image: rabbitmq
+  #   ports:
+  #     - "5672:5672"
+  #   expose:
+  #     - "5672"
+  


### PR DESCRIPTION
This pull request builds on the server-side rendering (SSR) and incorporates using `docker-compose` - enabling the user to quickly explore other services (running as separate containers) such as MongoDB, RabbitMQ, etc.

For the purposes of this project, I have left MongoDB and RabbitMQ commented out. If they are uncommented, the developer will be able to access these services at the following hostname and ports `mongodb:27017` and `rabbitmq:5672`, respectively.

One additional feature of this PR is to include the Redux DevTools extension for easier debugging of the React/Redux application.